### PR TITLE
Fix frontend build and form labels

### DIFF
--- a/FamilyTree.FrontEnd/FamilyTree.FrontEnd.Client/FamilyTree.FrontEnd.Client.csproj
+++ b/FamilyTree.FrontEnd/FamilyTree.FrontEnd.Client/FamilyTree.FrontEnd.Client.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.BlazorWebAssembly">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <NoDefaultLaunchSettingsFile>true</NoDefaultLaunchSettingsFile>
@@ -9,7 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.0"/>
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="8.0.0"/>
     </ItemGroup>
 
 </Project>

--- a/FamilyTree.FrontEnd/FamilyTree.FrontEnd.Client/Pages/Form.razor
+++ b/FamilyTree.FrontEnd/FamilyTree.FrontEnd.Client/Pages/Form.razor
@@ -13,8 +13,8 @@
         <ValidationMessage For="@(() => formData.Name)" />
     </div>
     <div>
-        <label for="email">Email:</label>
-        <InputText id="email" @bind-Value="formData.Surname" class="form-control" />
+        <label for="surname">Surname:</label>
+        <InputText id="surname" @bind-Value="formData.Surname" class="form-control" />
         <ValidationMessage For="@(() => formData.Surname)" />
     </div>
     <div>
@@ -32,7 +32,7 @@
     <ul>
         <li><strong>Name:</strong> @formData.Name</li>
         <li><strong>Surname:</strong> @formData.Surname</li>
-        <li><strong>Age:</strong> @formData.DeathDate?.ToShortDateString()</li>
+        <li><strong>Death Date:</strong> @formData.DeathDate?.ToShortDateString()</li>
     </ul>
 }
 

--- a/FamilyTree.FrontEnd/FamilyTree.FrontEnd/Components/App.razor
+++ b/FamilyTree.FrontEnd/FamilyTree.FrontEnd/Components/App.razor
@@ -5,10 +5,9 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <base href="/"/>
-    <link rel="stylesheet" href="@Assets["lib/bootstrap/dist/css/bootstrap.min.css"]"/>
-    <link rel="stylesheet" href="@Assets["app.css"]"/>
-    <link rel="stylesheet" href="@Assets["FamilyTree.FrontEnd.styles.css"]"/>
-    <ImportMap/>
+    <link rel="stylesheet" href="lib/bootstrap/dist/css/bootstrap.min.css"/>
+    <link rel="stylesheet" href="app.css"/>
+    <link rel="stylesheet" href="FamilyTree.FrontEnd.styles.css"/>
     <link rel="icon" type="image/png" href="favicon.png"/>
     <HeadOutlet/>
 </head>

--- a/FamilyTree.FrontEnd/FamilyTree.FrontEnd/FamilyTree.FrontEnd.csproj
+++ b/FamilyTree.FrontEnd/FamilyTree.FrontEnd/FamilyTree.FrontEnd.csproj
@@ -1,14 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>
 
     <ItemGroup>
         <ProjectReference Include="..\FamilyTree.FrontEnd.Client\FamilyTree.FrontEnd.Client.csproj"/>
-        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="9.0.0"/>
+        <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="8.0.0"/>
     </ItemGroup>
 
 </Project>

--- a/FamilyTree.FrontEnd/FamilyTree.FrontEnd/Program.cs
+++ b/FamilyTree.FrontEnd/FamilyTree.FrontEnd/Program.cs
@@ -26,7 +26,7 @@ app.UseHttpsRedirection();
 
 app.UseAntiforgery();
 
-app.MapStaticAssets();
+app.UseStaticFiles();
 app.MapRazorComponents<App>()
     .AddInteractiveWebAssemblyRenderMode()
     .AddAdditionalAssemblies(typeof(FamilyTree.FrontEnd.Client._Imports).Assembly);


### PR DESCRIPTION
## Summary
- downgrade projects to .NET 8 for available SDK
- fix static asset references and remove ImportMap
- replace `MapStaticAssets` with `UseStaticFiles`
- correct surname field label in form
- show death date instead of age in the confirmation

## Testing
- `dotnet build 'Family tree.sln'`

------
https://chatgpt.com/codex/tasks/task_e_688203fff694832980b011ab0eddae0c